### PR TITLE
Add Opus Growth — remote MCP connector for Google/Microsoft/TikTok/LinkedIn Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,7 @@ Every link above has been checked against the live page — a URL ships only whe
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - Model Context Protocol servers powering many of the connectors above.
 - [awesome-chatgpt-apps](https://github.com/rdmgator12/Chtgpt-Apps-Awesome-List) - Companion list cataloging apps in the ChatGPT directory.
 - [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) - LLM-powered applications across providers.
+- [Opus Growth](https://mcp.opus-growth.com) - Hosted MCP connector to manage Google Ads, Microsoft Advertising, TikTok Ads and LinkedIn Ads from Claude, ChatGPT and any MCP client. 233 tools, real writes with dry-run approval gates, agency/MCC-safe, hosted OAuth.
 
 ---
 


### PR DESCRIPTION
Adds **Opus Growth** — a hosted, remote MCP connector for advertising platforms.

Four ad platforms live: Google Ads (78 tools), Microsoft Advertising (30), TikTok Ads (25), LinkedIn Ads (18); plus the connected Google data sources (Search Console, GA4, Tag Manager, Business Profile, YouTube) — 233 tools total. Meta Ads is built and in final platform review.

Unlike read-only reporting connectors it performs **real write actions** (create/pause campaigns, budgets, bidding strategies, keywords and negatives, audiences, creatives), and every write is previewed as a **dry run** that applies only on the user's approval. Agency/MCC-safe via `login-customer-id`; hosted OAuth means no developer token, no API keys and nothing to self-host.

- Connector: https://mcp.opus-growth.com
- Site: https://opus-growth.com
- Official MCP Registry: `io.github.opusgrowth/ads-mcp`
- Tool catalog: https://github.com/opusgrowth/Opus-Growth-The-MCP-Connector-for-Ad-Platforms/blob/main/TOOLS.md
